### PR TITLE
Fix up/down socket streams. Improve TxAck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ license = "Apache-2.0"
 keywords = ["lorawan", "iot", "lpwan", "semtech"]
 repository = "https://github.com/helium/semtech-udp/"
 
+[[example]]
+name = "server"
+required-features = ["server"]
+
 [dependencies]
 num_enum = "0.4"
 arrayref = "0.3"
@@ -29,3 +33,4 @@ features = ["tcp", "udp", "rt-threaded", "macros", "sync", "time"]
 [features]
 default = []
 server = ["tokio"]
+

--- a/src/packet/parser.rs
+++ b/src/packet/parser.rs
@@ -44,9 +44,16 @@ impl Parser for Packet {
                 }
                 Identifier::TxAck => {
                     let gateway_mac = gateway_mac(&buffer[4..12]);
+                    let data = if num_recv > 12 {
+                        let json_str = std::str::from_utf8(&buffer[12..num_recv])?;
+                        Some(serde_json::from_str(json_str).unwrap())
+                    } else {
+                        None
+                    };
                     tx_ack::Packet {
                         random_token,
                         gateway_mac,
+                        data,
                     }
                     .into()
                 }

--- a/src/packet/pull_resp.rs
+++ b/src/packet/pull_resp.rs
@@ -10,7 +10,10 @@ Bytes  | Function
 3      | PULL_RESP identifier 0x03
 4-end  | JSON object, starting with {, ending with }, see section 6
  */
-use super::{tx_ack, write_preamble, Identifier, MacAddress, SerializablePacket, StringOrNum};
+use super::{
+    tx_ack, tx_ack::TxPkNack, write_preamble, Identifier, MacAddress, SerializablePacket,
+    StringOrNum,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     error::Error,
@@ -28,6 +31,15 @@ impl Packet {
         tx_ack::Packet {
             gateway_mac,
             random_token: self.random_token,
+            data: None,
+        }
+    }
+
+    pub fn into_nack_for_client(self, gateway_mac: MacAddress) -> tx_ack::Packet {
+        tx_ack::Packet {
+            gateway_mac,
+            random_token: self.random_token,
+            data: Some(TxPkNack::new(tx_ack::Error::UNKNOWN_MAC)),
         }
     }
 

--- a/src/packet/tx_ack.rs
+++ b/src/packet/tx_ack.rs
@@ -16,10 +16,11 @@ Bytes  | Function
 12-end | [optional] JSON object, starting with {, ending with }, see section 6
 
 */
-use super::super::simple_up_packet;
 use super::{write_preamble, Identifier, MacAddress, SerializablePacket};
+use serde::{Deserialize, Serialize};
 use std::{
-    error::Error,
+    error::Error as stdError,
+    fmt,
     io::{Cursor, Write},
 };
 
@@ -27,12 +28,113 @@ use std::{
 pub struct Packet {
     pub random_token: u16,
     pub gateway_mac: MacAddress,
+    pub data: Option<TxPkNack>,
 }
 
-simple_up_packet!(Packet, Identifier::TxAck);
+impl Packet {
+    pub fn has_error(&self) -> bool {
+        self.data.is_some()
+    }
+
+    pub fn get_error(&self) -> Option<Error> {
+        if let Some(txpk_ack) = &self.data {
+            Some(txpk_ack.txpk_ack.error)
+        } else {
+            None
+        }
+    }
+}
+
+impl SerializablePacket for Packet {
+    fn serialize(&self, buffer: &mut [u8]) -> std::result::Result<u64, Box<dyn stdError>> {
+        let mut w = Cursor::new(buffer);
+        write_preamble(&mut w, self.random_token)?;
+        w.write_all(&[Identifier::TxAck as u8])?;
+        if let Some(data) = &self.data {
+            w.write_all(&serde_json::to_string(&data)?.as_bytes())?;
+        }
+
+        Ok(w.position())
+    }
+}
 
 impl From<Packet> for super::Packet {
     fn from(packet: Packet) -> super::Packet {
         super::Packet::Up(super::Up::TxAck(packet))
     }
+}
+
+// Value             | Definition
+// :-----------------:|---------------------------------------------------------------------
+// NONE              | Packet has been programmed for downlink
+// TOO_LATE          | Rejected because it was already too late to program this packet for downlink
+// TOO_EARLY         | Rejected because downlink packet timestamp is too much in advance
+// COLLISION_PACKET  | Rejected because there was already a packet programmed in requested timeframe
+// COLLISION_BEACON  | Rejected because there was already a beacon planned in requested timeframe
+// TX_FREQ           | Rejected because requested frequency is not supported by TX RF chain
+// TX_POWER          | Rejected because requested power is not supported by gateway
+// GPS_UNLOCKED      | Rejected because GPS is unlocked, so GPS timestamp cannot be used
+//
+// Examples (white-spaces, indentation and newlines added for readability):
+//
+// ``` json
+// {"txpk_ack":{
+// "error":"COLLISION_PACKET"
+// }}
+// ```
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub enum Error {
+    NONE,
+    TOO_LATE,
+    TOO_EARLY,
+    COLLISION_PACKET,
+    COLLISION_BEACON,
+    TX_FREQ,
+    TX_POWER,
+    GPS_UNLOCKED,
+    UNKNOWN_MAC, // this is an added error type in case a client tries
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::NONE => write!(f, "TxAck::Error::NONE"),
+            Error::TOO_LATE => write!(f, "TxAck::Error::TOO_LATE"),
+            Error::TOO_EARLY => write!(f, "TxAck::Error::TOO_EARLY"),
+            Error::COLLISION_PACKET => write!(f, "TxAck::Error::COLLISION_PACKET"),
+            Error::COLLISION_BEACON => write!(f, "TxAck::Error::COLLISION_BEACON"),
+            Error::TX_FREQ => write!(f, "TxAck::Error::TX_FREQ, Transmit frequency is rejected"),
+            Error::TX_POWER => write!(f, "TxAck::Error::TX_POWER"),
+            Error::GPS_UNLOCKED => write!(f, "TxAck::Error::GPS_UNLOCKED"),
+            Error::UNKNOWN_MAC => write!(
+                f,
+                "TxAck::Error::UNKNOWN_MAC, Server does not have IP for MAC address requested"
+            ),
+        }
+    }
+}
+
+impl stdError for Error {
+    fn source(&self) -> Option<&(dyn stdError + 'static)> {
+        Some(self)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TxPkNack {
+    txpk_ack: SubTxPkAck,
+}
+
+impl TxPkNack {
+    pub fn new(error: Error) -> TxPkNack {
+        TxPkNack {
+            txpk_ack: SubTxPkAck { error },
+        }
+    }
+}
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct SubTxPkAck {
+    pub error: Error,
 }


### PR DESCRIPTION
I had previously conflated the "socket_up" and "socket_down" ports in Semtech's protocol, not realizing that two outbound sockets are used on behalf of the forwarder. It's ok to collapse them into a single host, but on the host's side you need to make sure you UDP frames going down are going to the appropriate outbound socket of the packet forwarder. In practice, this just means that the PUSH_ACK frame needs to be sent down to the socket that send the PUSH_DATA frame.