### PR TITLE
Server Runtime: Simplify Internals and Packet Receive Interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ name = "server"
 required-features = ["server"]
 
 [[example]]
+name = "server_split"
+required-features = ["server"]
+
+[[example]]
 name = "client"
 required-features = ["client"]
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -34,8 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let buffer = [1, 2, 3, 4];
                     let size = buffer.len() as u64;
                     let data = base64::encode(buffer);
-                    let tmst =
-                        StringOrNum::N(rxpk.get_timestamp() + 1_000_000);
+                    let tmst = StringOrNum::N(rxpk.get_timestamp() + 1_000_000);
 
                     let txpk = pull_resp::TxPk {
                         imme: false,
@@ -55,19 +54,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         ncrc: None,
                     };
 
-                    let prepared_send =
-                        udp_runtime.prepare_downlink(txpk, gateway_mac);
+                    let prepared_send = udp_runtime.prepare_downlink(txpk, gateway_mac);
 
                     tokio::spawn(async move {
-                        if let Err(e) =
-                            prepared_send.dispatch(Some(Duration::from_secs(5))).await
-                        {
+                        if let Err(e) = prepared_send.dispatch(Some(Duration::from_secs(5))).await {
                             panic!("Transmit Dispatch threw error: {:?}", e)
                         } else {
                             println!("Send complete");
                         }
                     });
-                },
+                }
                 Event::NoClientWithMac(_packet, mac) => {
                     println!("Tried to send to client with unknown MAC: {:?}", mac)
                 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -16,59 +16,57 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Ready for clients");
     loop {
         println!("Waiting for event");
-        if let Some(event) = udp_runtime.recv().await {
-            match event {
-                Event::UnableToParseUdpFrame(buf) => {
-                    println!("Semtech UDP Parsing Error");
-                    println!("UDP data: {:?}", buf);
-                }
-                Event::NewClient((mac, addr)) => {
-                    println!("New packet forwarder client: {}, {}", mac, addr);
-                }
-                Event::UpdateClient((mac, addr)) => {
-                    println!("Mac existed, but IP updated: {}, {}", mac, addr);
-                }
-                Event::PacketReceived(rxpk, gateway_mac) => {
-                    println!("{:?}", rxpk);
-
-                    let buffer = [1, 2, 3, 4];
-                    let size = buffer.len() as u64;
-                    let data = base64::encode(buffer);
-                    let tmst = StringOrNum::N(rxpk.get_timestamp() + 1_000_000);
-
-                    let txpk = pull_resp::TxPk {
-                        imme: false,
-                        tmst,
-                        freq: 902.800_000,
-                        rfch: 0,
-                        powe: 27,
-                        modu: "LORA".to_string(),
-                        datr: "SF8BW500".to_string(),
-                        codr: "4/5".to_string(),
-                        ipol: true,
-                        size,
-                        data,
-                        tmms: None,
-                        fdev: None,
-                        prea: None,
-                        ncrc: None,
-                    };
-
-                    let prepared_send = udp_runtime.prepare_downlink(txpk, gateway_mac);
-
-                    tokio::spawn(async move {
-                        if let Err(e) = prepared_send.dispatch(Some(Duration::from_secs(5))).await {
-                            panic!("Transmit Dispatch threw error: {:?}", e)
-                        } else {
-                            println!("Send complete");
-                        }
-                    });
-                }
-                Event::NoClientWithMac(_packet, mac) => {
-                    println!("Tried to send to client with unknown MAC: {:?}", mac)
-                }
-                Event::RawPacket(_) => (),
+        match udp_runtime.recv().await {
+            Event::UnableToParseUdpFrame(buf) => {
+                println!("Semtech UDP Parsing Error");
+                println!("UDP data: {:?}", buf);
             }
+            Event::NewClient((mac, addr)) => {
+                println!("New packet forwarder client: {}, {}", mac, addr);
+            }
+            Event::UpdateClient((mac, addr)) => {
+                println!("Mac existed, but IP updated: {}, {}", mac, addr);
+            }
+            Event::PacketReceived(rxpk, gateway_mac) => {
+                println!("{:?}", rxpk);
+
+                let buffer = [1, 2, 3, 4];
+                let size = buffer.len() as u64;
+                let data = base64::encode(buffer);
+                let tmst = StringOrNum::N(rxpk.get_timestamp() + 1_000_000);
+
+                let txpk = pull_resp::TxPk {
+                    imme: false,
+                    tmst,
+                    freq: 902.800_000,
+                    rfch: 0,
+                    powe: 27,
+                    modu: "LORA".to_string(),
+                    datr: "SF8BW500".to_string(),
+                    codr: "4/5".to_string(),
+                    ipol: true,
+                    size,
+                    data,
+                    tmms: None,
+                    fdev: None,
+                    prea: None,
+                    ncrc: None,
+                };
+
+                let prepared_send = udp_runtime.prepare_downlink(txpk, gateway_mac);
+
+                tokio::spawn(async move {
+                    if let Err(e) = prepared_send.dispatch(Some(Duration::from_secs(5))).await {
+                        panic!("Transmit Dispatch threw error: {:?}", e)
+                    } else {
+                        println!("Send complete");
+                    }
+                });
+            }
+            Event::NoClientWithMac(_packet, mac) => {
+                println!("Tried to send to client with unknown MAC: {:?}", mac)
+            }
+            Event::RawPacket(_) => (),
         }
     }
 }

--- a/examples/server_split.rs
+++ b/examples/server_split.rs
@@ -1,0 +1,133 @@
+use semtech_udp::{
+    pull_resp,
+    server_runtime::{Event, UdpRuntime},
+    MacAddress, StringOrNum,
+};
+use std::net::SocketAddr;
+use structopt::StructOpt;
+use tokio::sync::oneshot::{self, Receiver, Sender};
+use tokio::time::{delay_for as sleep, Duration};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Opt::from_args();
+    let addr = SocketAddr::from(([0, 0, 0, 0], cli.port));
+    println!("Starting server: {}", addr);
+
+    // Splitting is optional and only useful if you are want to run concurrently
+    // the client_rx & client_tx can both be held inside the UdpRuntime struct
+    let (mut client_rx, mut client_tx) = UdpRuntime::new(addr).await?.split();
+
+    // prepare a one-shot so that receive can unlocked sending
+    let (tx, rx): (Sender<MacAddress>, Receiver<MacAddress>) = oneshot::channel();
+    let mut tx = Some(tx);
+
+    // spawn off tx thread for sending packets
+    tokio::spawn(async move {
+        let gateway_mac = rx.await.unwrap();
+        let mut first_shot = true;
+        while cli.delay != 0 || first_shot {
+            first_shot = false;
+            let buffer = vec![0; cli.length];
+            let size = buffer.len() as u64;
+            let data = base64::encode(buffer);
+            let tmst = StringOrNum::N(0);
+
+            let txpk = pull_resp::TxPk {
+                imme: true,
+                tmst,
+                freq: cli.frequency,
+                rfch: 0,
+                powe: cli.power as u64,
+                modu: "LORA".to_string(),
+                datr: cli.data_rate.clone(),
+                codr: "4/5".to_string(),
+                ipol: cli.polarization_inversion,
+                size,
+                data,
+                tmms: None,
+                fdev: None,
+                prea: None,
+                ncrc: None,
+            };
+
+            println!("Sending: {:?}", txpk);
+
+            let prepared_send = client_tx.prepare_downlink(Some(txpk), gateway_mac);
+
+            tokio::spawn(async move {
+                if let Err(e) = prepared_send.dispatch(Some(Duration::from_secs(5))).await {
+                    panic!("Transmit Dispatch threw error: {:?}", e)
+                } else {
+                    println!("Send complete");
+                }
+            });
+
+            sleep(Duration::from_secs(cli.delay)).await;
+        }
+    });
+
+    println!("Ready for clients");
+    loop {
+        if let Some(event) = client_rx.recv().await {
+            match event {
+                Event::UnableToParseUdpFrame(buf) => {
+                    println!("Semtech UDP Parsing Error");
+                    println!("UDP data: {:?}", buf);
+                }
+                Event::NewClient((mac, addr)) => {
+                    println!("New packet forwarder client: {}, {}", mac, addr);
+
+                    // unlock the tx thread by sending it the gateway mac of the
+                    // the first client (connection via PULL_DATA frame)
+                    if let Some(tx) = tx.take() {
+                        tx.send(mac).unwrap();
+                    }
+                }
+                Event::UpdateClient((mac, addr)) => {
+                    println!("Mac existed, but IP updated: {}, {}", mac, addr);
+                }
+                Event::PacketReceived(rxpk, addr) => {
+                    println!("Packet Receveived from {}:", addr);
+                    println!("{:?}", rxpk);
+                }
+                Event::NoClientWithMac(_packet, mac) => {
+                    println!("Tried to send to client with unknown MAC: {:?}", mac)
+                }
+                Event::RawPacket(_) => (),
+            }
+        }
+    }
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "semtech-server", about = "LoRa test device utility")]
+pub struct Opt {
+    /// Port to run service on
+    #[structopt(long, default_value = "1680")]
+    port: u16,
+
+    /// Power output
+    #[structopt(long, default_value = "27")]
+    power: u8,
+
+    /// Length
+    #[structopt(long, default_value = "52")]
+    length: usize,
+
+    /// Seconds of delay between transmits. Set to 0 for one-shot
+    #[structopt(long, default_value = "0")]
+    delay: u64,
+
+    /// Transmit frequency in MHz
+    #[structopt(long, default_value = "868.1")]
+    frequency: f64,
+
+    /// Data rate (Spreading Factor / Bandwidth)
+    #[structopt(long, default_value = "SF12BW125")]
+    data_rate: String,
+
+    /// Polarization inversion (set true when sending to devices)
+    #[structopt(long)]
+    polarization_inversion: bool,
+}

--- a/examples/server_split.rs
+++ b/examples/server_split.rs
@@ -69,33 +69,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Ready for clients");
     loop {
-        if let Some(event) = client_rx.recv().await {
-            match event {
-                Event::UnableToParseUdpFrame(buf) => {
-                    println!("Semtech UDP Parsing Error");
-                    println!("UDP data: {:?}", buf);
-                }
-                Event::NewClient((mac, addr)) => {
-                    println!("New packet forwarder client: {}, {}", mac, addr);
-
-                    // unlock the tx thread by sending it the gateway mac of the
-                    // the first client (connection via PULL_DATA frame)
-                    if let Some(tx) = tx.take() {
-                        tx.send(mac).unwrap();
-                    }
-                }
-                Event::UpdateClient((mac, addr)) => {
-                    println!("Mac existed, but IP updated: {}, {}", mac, addr);
-                }
-                Event::PacketReceived(rxpk, addr) => {
-                    println!("Packet Receveived from {}:", addr);
-                    println!("{:?}", rxpk);
-                }
-                Event::NoClientWithMac(_packet, mac) => {
-                    println!("Tried to send to client with unknown MAC: {:?}", mac)
-                }
-                Event::RawPacket(_) => (),
+        match client_rx.recv().await {
+            Event::UnableToParseUdpFrame(buf) => {
+                println!("Semtech UDP Parsing Error");
+                println!("UDP data: {:?}", buf);
             }
+            Event::NewClient((mac, addr)) => {
+                println!("New packet forwarder client: {}, {}", mac, addr);
+
+                // unlock the tx thread by sending it the gateway mac of the
+                // the first client (connection via PULL_DATA frame)
+                if let Some(tx) = tx.take() {
+                    tx.send(mac).unwrap();
+                }
+            }
+            Event::UpdateClient((mac, addr)) => {
+                println!("Mac existed, but IP updated: {}, {}", mac, addr);
+            }
+            Event::PacketReceived(rxpk, addr) => {
+                println!("Packet Receveived from {}:", addr);
+                println!("{:?}", rxpk);
+            }
+            Event::NoClientWithMac(_packet, mac) => {
+                println!("Tried to send to client with unknown MAC: {:?}", mac)
+            }
+            Event::RawPacket(_) => (),
         }
     }
 }

--- a/src/client_runtime.rs
+++ b/src/client_runtime.rs
@@ -166,6 +166,8 @@ impl UdpRuntimeRx {
                 }
                 Err(e) => {
                     println!("Socket receive error: {}", e);
+                    // back off of CPU
+                    sleep(Duration::from_secs(10)).await;
                 }
             }
         }
@@ -199,6 +201,8 @@ impl UdpRuntimeTx {
 
                 if let Err(e) = self.socket_send.send(&buf[..n]).await {
                     println!("Socket error: {}", e);
+                    // back off of CPU
+                    sleep(Duration::from_secs(10)).await;
                 }
             }
         }

--- a/src/client_runtime.rs
+++ b/src/client_runtime.rs
@@ -147,7 +147,7 @@ impl UdpRuntimeRx {
         loop {
             match self.socket_recv.recv(&mut buf).await {
                 Ok(n) => {
-                    let packet = Packet::parse(&buf[0..n], n)?;
+                    let packet = Packet::parse(&buf[0..n])?;
                     match packet {
                         Packet::Up(_) => panic!("Should not be receiving any up packets"),
                         Packet::Down(down) => match down.clone() {

--- a/src/server_runtime.rs
+++ b/src/server_runtime.rs
@@ -1,5 +1,6 @@
 use super::{
-    parser::Parser, pull_resp, pull_resp::TxPk, Down, MacAddress, Packet, SerializablePacket, Up,
+    parser::Parser, pull_resp, pull_resp::TxPk, tx_ack::Packet as TxAck, MacAddress, Packet,
+    SerializablePacket, Up,
 };
 use std::{collections::HashMap, net::SocketAddr, time::Duration};
 use tokio::{
@@ -7,23 +8,27 @@ use tokio::{
         udp::{RecvHalf, SendHalf},
         UdpSocket,
     },
-    sync::{
-        broadcast,
-        mpsc::{self, Receiver, Sender},
-    },
+    sync::{mpsc, oneshot},
     time::timeout,
 };
 
+pub use crate::push_data::RxPk;
+
 #[derive(Debug)]
-enum UdpMessage {
-    PacketByMac((Packet, MacAddress)),
+enum InternalEvent {
+    Downlink((pull_resp::Packet, MacAddress, oneshot::Sender<TxAck>)),
+    RawPacket(Up),
     PacketBySocket((Packet, SocketAddr)),
     Client((MacAddress, SocketAddr)),
+    PacketReceived(RxPk, MacAddress),
+    UnableToParseUdpFrame(Vec<u8>),
+    AckReceived(TxAck),
 }
 
 #[derive(Debug, Clone)]
 pub enum Event {
-    Packet(Up),
+    PacketReceived(RxPk, MacAddress),
+    RawPacket(Up),
     NewClient((MacAddress, SocketAddr)),
     UpdateClient((MacAddress, SocketAddr)),
     UnableToParseUdpFrame(Vec<u8>),
@@ -34,27 +39,26 @@ pub enum Event {
 // dispatches them to UdpTx
 #[derive(Debug)]
 pub struct ClientTx {
-    sender: Sender<UdpMessage>,
+    sender: mpsc::Sender<InternalEvent>,
     // you need to subscribe to the send channel
-    receiver_copier: broadcast::Sender<Event>,
+    receiver_copier: mpsc::Sender<Event>,
 }
 
 // sends packets to clients
-// broadcast enables many clients
-pub type ClientRx = broadcast::Receiver<Event>;
+pub type ClientRx = mpsc::Receiver<Event>;
 
-// receives UDP packets
+// receives and parses UDP packets
 struct UdpRx {
     socket_receiver: RecvHalf,
-    udp_tx_sender: Sender<UdpMessage>,
-    client_tx_sender: broadcast::Sender<Event>,
+    internal_sender: mpsc::Sender<InternalEvent>,
 }
 
-// transmits UDP packets
-struct UdpTx {
-    receiver: Receiver<UdpMessage>,
-    client_tx_sender: broadcast::Sender<Event>,
+// processes Internal Events and Transmit over UDP
+struct Internal {
+    receiver: mpsc::Receiver<InternalEvent>,
+    client_tx_sender: mpsc::Sender<Event>,
     clients: HashMap<MacAddress, SocketAddr>,
+    downlink_senders: HashMap<u16, oneshot::Sender<TxAck>>,
     socket_sender: SendHalf,
 }
 
@@ -67,24 +71,25 @@ use rand::Rng;
 
 #[derive(Debug)]
 pub enum Error {
-    QueueFull(mpsc::error::SendError<(Packet, MacAddress)>),
-    AckChannelRecv(broadcast::RecvError),
+    AckChannelRecv(mpsc::error::RecvError),
     AckError(super::packet::tx_ack::Error),
     SendTimeout,
     DispatchWithNoSendPacket,
     UnknownMac,
     UdpError(std::io::Error),
-    ClientEventQueueFull(broadcast::SendError<Event>),
-    SocketEventQueueFull,
+    ClientEventQueueFull(Box<mpsc::error::SendError<Event>>),
+    InternalQueueClosedOrFull,
     SemtechUdpSerialization(super::packet::Error),
+    AckRecvError,
+    ErrorSendingAck,
 }
 
+#[derive(Clone)]
 pub struct Downlink {
     random_token: u16,
     mac: MacAddress,
     packet: Option<pull_resp::Packet>,
-    sender: Sender<UdpMessage>,
-    receiver: broadcast::Receiver<Event>,
+    sender: mpsc::Sender<InternalEvent>,
 }
 
 impl Downlink {
@@ -95,34 +100,20 @@ impl Downlink {
         });
     }
 
-    async fn just_dispatch(self) -> Result<(), Error> {
-        let (mut sender, mut receiver) = (self.sender, self.receiver);
-
+    async fn just_dispatch(mut self) -> Result<(), Error> {
         if let Some(packet) = self.packet {
-            // send it to UdpTx channel
-            sender
-                .send(UdpMessage::PacketByMac((packet.into(), self.mac)))
+            let (sender, receiver) = oneshot::channel();
+
+            self.sender
+                .send(InternalEvent::Downlink((packet, self.mac, sender)))
                 .await?;
 
-            // loop over responses until the TxAck is received
-            loop {
-                match receiver.recv().await? {
-                    Event::Packet(packet) => {
-                        if let Up::TxAck(ack) = packet {
-                            if ack.random_token == self.random_token {
-                                return if let Some(error) = ack.get_error() {
-                                    Err(error.into())
-                                } else {
-                                    Ok(())
-                                };
-                            }
-                        }
-                    }
-                    Event::NoClientWithMac(_packet, _mac) => {
-                        return Err(Error::UnknownMac);
-                    }
-                    _ => (),
-                }
+            // wait for the ACK for the protocol layer
+            let ack = receiver.await?;
+            if let Some(error) = ack.get_error() {
+                Err(error.into())
+            } else {
+                Ok(())
             }
         } else {
             Err(Error::DispatchWithNoSendPacket)
@@ -168,11 +159,10 @@ impl ClientTx {
             mac,
             packet,
             sender: self.get_sender(),
-            receiver: self.receiver_copier.subscribe(),
         }
     }
 
-    fn get_sender(&mut self) -> Sender<UdpMessage> {
+    fn get_sender(&mut self) -> mpsc::Sender<InternalEvent> {
         self.sender.clone()
     }
 }
@@ -199,7 +189,7 @@ impl UdpRuntime {
         self.tx.prepare_downlink(Some(txpk), mac)
     }
 
-    pub async fn recv(&mut self) -> Result<Event, broadcast::RecvError> {
+    pub async fn recv(&mut self) -> Option<Event> {
         self.rx.recv().await
     }
 
@@ -208,27 +198,25 @@ impl UdpRuntime {
         let (socket_receiver, socket_sender) = socket.split();
 
         let (udp_tx_sender, udp_tx_receiver) = mpsc::channel(100);
+        let (client_tx_sender, client_tx_receiver) = mpsc::channel(100);
 
-        // broadcasts to client
-        let (client_tx_sender, client_tx_receiver) = broadcast::channel(100);
+        let client_tx = client_tx_receiver;
 
         let client_rx = ClientTx {
             sender: udp_tx_sender.clone(),
             receiver_copier: client_tx_sender.clone(),
         };
 
-        let client_tx = client_tx_receiver;
-
         let udp_rx = UdpRx {
             socket_receiver,
-            udp_tx_sender,
-            client_tx_sender: client_tx_sender.clone(),
+            internal_sender: udp_tx_sender,
         };
 
-        let udp_tx = UdpTx {
+        let udp_tx = Internal {
             receiver: udp_tx_receiver,
             client_tx_sender,
             clients: HashMap::new(),
+            downlink_senders: HashMap::new(),
             socket_sender,
         };
 
@@ -267,8 +255,9 @@ impl UdpRx {
                     } else {
                         let mut vec = Vec::new();
                         vec.extend_from_slice(&buf[0..n]);
-                        self.client_tx_sender
-                            .send(Event::UnableToParseUdpFrame(vec))?;
+                        self.internal_sender
+                            .send(InternalEvent::UnableToParseUdpFrame(vec))
+                            .await?;
                         None
                     };
 
@@ -276,33 +265,56 @@ impl UdpRx {
                         match packet {
                             Packet::Up(packet) => {
                                 // echo all packets to client
-                                self.client_tx_sender.send(Event::Packet(packet.clone()))?;
+                                self.internal_sender
+                                    .send(InternalEvent::RawPacket(packet.clone()))
+                                    .await?;
+
                                 match packet {
                                     Up::PullData(pull_data) => {
                                         let mac = pull_data.gateway_mac;
                                         // first send (mac, addr) to update map owned by UdpRuntimeTx
                                         let client = (mac, src);
-                                        self.udp_tx_sender.send(UdpMessage::Client(client)).await?;
+                                        self.internal_sender
+                                            .send(InternalEvent::Client(client))
+                                            .await?;
 
                                         // send the ack_packet
                                         let ack_packet = pull_data.into_ack();
-                                        let mut udp_tx = self.udp_tx_sender.clone();
-                                        udp_tx
-                                            .send(UdpMessage::PacketByMac((ack_packet.into(), mac)))
+                                        self.internal_sender
+                                            .send(InternalEvent::PacketBySocket((
+                                                ack_packet.into(),
+                                                src,
+                                            )))
                                             .await?
                                     }
+                                    Up::TxAck(txack) => {
+                                        self.internal_sender
+                                            .send(InternalEvent::AckReceived(txack))
+                                            .await?;
+                                    }
                                     Up::PushData(push_data) => {
+                                        // Send all received packets as RxPk Events
+                                        if let Some(rxpk) = &push_data.data.rxpk {
+                                            for packet in rxpk {
+                                                self.internal_sender
+                                                    .send(InternalEvent::PacketReceived(
+                                                        packet.clone(),
+                                                        push_data.gateway_mac,
+                                                    ))
+                                                    .await?;
+                                            }
+                                        }
+
                                         let socket_addr = src;
                                         // send the ack_packet
                                         let ack_packet = push_data.into_ack();
-                                        self.udp_tx_sender
-                                            .send(UdpMessage::PacketBySocket((
+                                        self.internal_sender
+                                            .send(InternalEvent::PacketBySocket((
                                                 ack_packet.into(),
                                                 socket_addr,
                                             )))
                                             .await?;
                                     }
-                                    _ => (),
                                 }
                             }
                             Packet::Down(_) => {
@@ -316,40 +328,78 @@ impl UdpRx {
     }
 }
 
-impl UdpTx {
+impl Internal {
     pub async fn run(mut self) -> Result<(), Error> {
         let mut buf = vec![0u8; 1024];
         loop {
             let msg = self.receiver.recv().await;
             if let Some(msg) = msg {
                 match msg {
-                    UdpMessage::PacketByMac((packet, mac)) => {
+                    InternalEvent::RawPacket(up) => {
+                        self.client_tx_sender.send(Event::RawPacket(up)).await?;
+                    }
+                    InternalEvent::UnableToParseUdpFrame(frame) => {
+                        self.client_tx_sender
+                            .send(Event::UnableToParseUdpFrame(frame))
+                            .await?;
+                    }
+                    InternalEvent::PacketReceived(rxpk, mac) => {
+                        self.client_tx_sender
+                            .send(Event::PacketReceived(rxpk, mac))
+                            .await?;
+                    }
+                    InternalEvent::Downlink((packet, mac, ack_sender)) => {
+                        let mut no_client = true;
+
                         if let Some(addr) = self.clients.get(&mac) {
                             let n = packet.serialize(&mut buf)? as usize;
-                            let _sent = self.socket_sender.send_to(&buf[..n], addr).await?;
-                        } else if let Packet::Down(Down::PullResp(pull_resp)) = packet {
+                            // We receive an error here if we are trying to send the packet to a
+                            // client that is no longer connected to us. Delete the client from map
+                            if self.socket_sender.send_to(&buf[..n], addr).await.is_err() {
+                                self.clients.remove(&mac);
+                            } else {
+                                // store token and one-shot channel
+                                self.downlink_senders
+                                    .insert(packet.random_token, ack_sender);
+                                no_client = false;
+                            }
+                        }
+                        if no_client {
                             self.client_tx_sender
-                                .send(Event::NoClientWithMac(pull_resp, mac))
-                                .unwrap();
+                                .send(Event::NoClientWithMac(packet.into(), mac))
+                                .await?;
                         }
                     }
-                    UdpMessage::PacketBySocket((packet, addr)) => {
-                        let n = packet.serialize(&mut buf)? as usize;
-                        let _sent = self.socket_sender.send_to(&buf[..n], &addr).await?;
+                    InternalEvent::AckReceived(txack) => {
+                        if let Some(sender) = self.downlink_senders.remove(&txack.random_token) {
+                            sender.send(txack).map_err(|_| Error::ErrorSendingAck)?;
+                        } else {
+                            eprintln!("ACK received for unknown random_token")
+                        }
                     }
-                    UdpMessage::Client((mac, addr)) => {
+                    InternalEvent::PacketBySocket((packet, addr)) => {
+                        let n = packet.serialize(&mut buf)? as usize;
+                        // only ACKs are sent via PacketBySocket
+                        // so this will be an error only if we have somehow lost UDP connection
+                        // between receiving a packet and sending the ACK
+                        let _ = self.socket_sender.send_to(&buf[..n], &addr).await;
+                    }
+                    InternalEvent::Client((mac, addr)) => {
                         // tell user if same MAC has new IP
                         if let Some(existing_addr) = self.clients.get(&mac) {
                             if *existing_addr != addr {
                                 self.clients.insert(mac, addr);
                                 self.client_tx_sender
-                                    .send(Event::UpdateClient((mac, addr)))?;
+                                    .send(Event::UpdateClient((mac, addr)))
+                                    .await?;
                             }
                         }
                         // simply insert if no entry exists
                         else {
                             self.clients.insert(mac, addr);
-                            self.client_tx_sender.send(Event::NewClient((mac, addr)))?;
+                            self.client_tx_sender
+                                .send(Event::NewClient((mac, addr)))
+                                .await?;
                         }
                     }
                 }
@@ -370,15 +420,15 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<broadcast::SendError<Event>> for Error {
-    fn from(err: broadcast::SendError<Event>) -> Error {
-        Error::ClientEventQueueFull(err)
+impl From<mpsc::error::SendError<Event>> for Error {
+    fn from(err: mpsc::error::SendError<Event>) -> Error {
+        Error::ClientEventQueueFull(err.into())
     }
 }
 
-impl From<mpsc::error::SendError<UdpMessage>> for Error {
-    fn from(_err: mpsc::error::SendError<UdpMessage>) -> Error {
-        Error::SocketEventQueueFull
+impl From<mpsc::error::SendError<InternalEvent>> for Error {
+    fn from(_err: mpsc::error::SendError<InternalEvent>) -> Error {
+        Error::InternalQueueClosedOrFull
     }
 }
 
@@ -388,14 +438,8 @@ impl From<super::packet::Error> for Error {
     }
 }
 
-impl From<mpsc::error::SendError<(Packet, MacAddress)>> for Error {
-    fn from(e: mpsc::error::SendError<(Packet, MacAddress)>) -> Self {
-        Error::QueueFull(e)
-    }
-}
-
-impl From<broadcast::RecvError> for Error {
-    fn from(e: broadcast::RecvError) -> Self {
+impl From<mpsc::error::RecvError> for Error {
+    fn from(e: mpsc::error::RecvError) -> Self {
         Error::AckChannelRecv(e)
     }
 }
@@ -406,23 +450,30 @@ impl From<super::packet::tx_ack::Error> for Error {
     }
 }
 
+impl From<oneshot::error::RecvError> for Error {
+    fn from(_: oneshot::error::RecvError) -> Self {
+        Error::AckRecvError
+    }
+}
+
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let msg = match self {
-            Error::QueueFull(event) => format!("QueueFull. Droppping event: {}", event),
             Error::AckChannelRecv(_) => "AckChannelRecv".to_string(),
-            Error::AckError(error) => format!("AckError on trasmit {}", error),
+            Error::AckError(error) => format!("AckError on transmit {}", error),
             Error::UnknownMac => "UnknownMac on on transmit".to_string(),
             Error::UdpError(error) => format!("UdpError: {}", error),
             Error::ClientEventQueueFull(event) => {
-                format!("ClientEventQueueFull. Droppping event: {:?}", event)
+                format!("Client Event Queue Full. Dropping event: {:?}", event)
             }
-            Error::SocketEventQueueFull => "Internal UDP buffer full".to_string(),
+            Error::InternalQueueClosedOrFull => "Internal Queue Full or Closed".to_string(),
             Error::SemtechUdpSerialization(err) => {
-                format!("SemtechUdpSerilaization Error: {:?}", err)
+                format!("Semtech Udp Serialization Error: {:?}", err)
             }
-            Error::SendTimeout => format!("Sending RF Packet Timed Out"),
-            Error::DispatchWithNoSendPacket => format!("Dispatched PreparedSend with no Packet"),
+            Error::SendTimeout => "Sending RF Packet Timed Out".to_string(),
+            Error::DispatchWithNoSendPacket => "Dispatched PreparedSend with no Packet".to_string(),
+            Error::AckRecvError => "Error waiting for ACK at sending process".to_string(),
+            Error::ErrorSendingAck => "Error sending ACK to sending process".to_string(),
         };
         write!(f, "{}", msg)
     }
@@ -433,16 +484,17 @@ use std::error::Error as StdError;
 impl StdError for Error {
     fn description(&self) -> &str {
         match self {
-            Error::QueueFull(_) => "QueueFull",
             Error::AckChannelRecv(_) => "AckChannelRecv",
-            Error::AckError(_) => "AckError on trasmit",
+            Error::AckError(_) => "AckError on transmit",
             Error::UnknownMac => "UnknownMac on on transmit",
             Error::UdpError(_) => "UdpError",
-            Error::ClientEventQueueFull(_) => "ClientEventQueueFull. Droppping event",
-            Error::SocketEventQueueFull => "Internal UDP buffer full",
-            Error::SemtechUdpSerialization(_) => "SemtechUdpSerilaization Error",
+            Error::ClientEventQueueFull(_) => "Client Event Queue Full. Dropping event",
+            Error::InternalQueueClosedOrFull => "Internal Queue Full or Closed",
+            Error::SemtechUdpSerialization(_) => "Semtech Udp Serialization Error",
             Error::SendTimeout => "Sending RF Packet Timed Out",
             Error::DispatchWithNoSendPacket => "Dispatched PreparedSend with no Packet",
+            Error::AckRecvError => "Error waiting for ACK at sending process",
+            Error::ErrorSendingAck => "Error sending ACK to sending process",
         }
     }
 }

--- a/src/server_runtime.rs
+++ b/src/server_runtime.rs
@@ -262,7 +262,7 @@ impl UdpRx {
             match self.socket_receiver.recv_from(&mut buf).await {
                 Err(e) => return Err(e.into()),
                 Ok((n, src)) => {
-                    let packet = if let Ok(packet) = Packet::parse(&buf[0..n], n) {
+                    let packet = if let Ok(packet) = Packet::parse(&buf[0..n]) {
                         Some(packet)
                     } else {
                         let mut vec = Vec::new();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,7 +5,7 @@ fn test_pull_data() {
     let recv = [
         0x2, 0x9F, 0x92, 0x2, 0xAA, 0x55, 0x5A, 0x1, 0x2, 0x3, 0x4, 0x5,
     ];
-    let packet = Packet::parse(&recv, recv.len()).unwrap();
+    let packet = Packet::parse(&recv).unwrap();
 
     if let Packet::Up(Up::PullData(packet)) = packet {
         let mut buffer = [0; 512];
@@ -39,12 +39,12 @@ fn test_push_data_rxpk() {
         0x44, 0x59, 0x43, 0x4E, 0x72, 0x41, 0x3D, 0x22, 0x7D, 0x5D, 0x7D,
     ];
 
-    let packet = Packet::parse(&recv, recv.len()).unwrap();
+    let packet = Packet::parse(&recv).unwrap();
 
     if let Packet::Up(Up::PushData(packet)) = packet {
         let mut buffer = [0; 512];
         let written = packet.serialize(&mut buffer).unwrap();
-        let _packet = Packet::parse(&buffer, written as usize).unwrap();
+        let _packet = Packet::parse(&buffer[..written as usize]).unwrap();
     } else {
         assert!(false);
     }
@@ -68,12 +68,12 @@ fn test_push_data_rxpk_jsonv2() {
         51, 49, 51, 57, 57, 56, 56, 55, 54, 125, 93, 125,
     ];
 
-    let packet = Packet::parse(&recv, recv.len()).unwrap();
+    let packet = Packet::parse(&recv).unwrap();
 
     if let Packet::Up(Up::PushData(packet)) = packet {
         let mut buffer = [0; 512];
         let written = packet.serialize(&mut buffer).unwrap();
-        let _packet = Packet::parse(&buffer, written as usize).unwrap();
+        let _packet = Packet::parse(&buffer[..written as usize]).unwrap();
     } else {
         assert!(false);
     }
@@ -92,15 +92,15 @@ fn test_push_data_stat() {
         0x22, 0x3A, 0x30, 0x7D, 0x7D,
     ];
 
-    let packet = Packet::parse(&recv, recv.len()).unwrap();
+    let packet = Packet::parse(&recv).unwrap();
 
     if let Packet::Up(Up::PushData(packet)) = packet {
-        let _packet_first_read = Packet::parse(&recv, recv.len()).unwrap();
+        let _packet_first_read = Packet::parse(&recv).unwrap();
 
         let mut buffer_first = [0; 512];
         let written_first = packet.serialize(&mut buffer_first).unwrap();
 
-        let packet_second_read = Packet::parse(&buffer_first, written_first as usize).unwrap();
+        let packet_second_read = Packet::parse(&buffer_first[..written_first as usize]).unwrap();
         if let Packet::Up(Up::PushData(packet_second_read)) = packet_second_read {
             let mut buffer_second = [0; 512];
             let _written_second = packet_second_read.serialize(&mut buffer_second).unwrap();


### PR DESCRIPTION
A broadcast channel was used inside the `server_runtime` since the implementation of a send confirmation (watching for the appropriate tx_ack) was a bit of a mess: each `Downlink` struct was monitoring all received packets for the ACK. Not only did that means packets of UDP packets were being passed around unnecessarily, but it also made it impossible to clone the `Downlink` struct.

With these changes, the `Downlink` registers itself with the ClientRx thread who is now the only receiver of received UDP frames. A one-shot channel allows the ClientRx to send the ACK result. This leaves the responsibility of checking the matching random_token to the `ClientRx` thread, instead of having each `Downlink` receiving its own copy of every single packet, checking if its an ACK, and then checking if the ACK it _its_ ACK with the appropriate `random_token`.

In addition, the client event interface has changed slightly. Whereas before all UDP frames were shared with the client via the `Event::Packet`, those events have been renamed `Event::RawPacket`. Meanwhile, received radio frames are also shared via the `Event::PacktetReceived`. This makes it easy for clients to focus on received packets without match on packet type and then iterating through all potential received packets in that single UDP frame.

Within this PR, there are a few other minor improvements:

- the client runtime was aggressively retrying when there was no connection which basically locks up a CPU core
- the server example has been improved to be more useful in gateway testing; it now sends one or more downlinks that are CLI configurable
