### PR TITLE
Improve Types in Packets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,10 @@ serde_json = { version = "1.0" }
 serde = { version = "1.0.100", default-features = false,  features = ["derive"] }
 serde_repr = "0.1"
 rand = "0.7.3"
+base64 = "0.13.0"
 
 [dev-dependencies]
-etherparse = "0.9.0"
-pcap = "0.7.0"
 lorawan = "0.6.0"
-base64 = "0.12.0"
 structopt = { version = "0.3.2", default-features = false }
 
 [dependencies.tokio]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ num_enum = "0.4"
 arrayref = "0.3"
 serde_json = { version = "1.0" }
 serde = { version = "1.0.100", default-features = false,  features = ["derive"] }
+serde_repr = "0.1"
 rand = "0.7.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semtech-udp"
-version = "0.4.2-alpha.0"
+version = "0.5.0"
 authors = ["Louis Thiery <thiery.louis@gmail.com>"]
 edition = "2018"
 description = "Semtech UDP provides serialization and deserialization of packets complying with the Semtech UDP protocol"

--- a/README.md
+++ b/README.md
@@ -2,13 +2,10 @@
 
 # Semtech UDP
 
-Semtech UDP provides serialization and deserialization of packets complying
-with the Semtech UDP protocol.
+Semtech UDP provides serialization and deserialization of packets complying with the Semtech GWMP over UDP protocol.
 
-The **server** feature provides a Tokio-based runtime which handles  all the
-UDP and Semtech UDP protocol details, such as ACKs and keeping track of client
-addresses. 
+The `server` feature provides a Tokio-based runtime which handles the UDP and Semtech GWMP UDP protocol details, such as
+ACKs and keeping track of client addresses. It exposes an async API for receiving all messages for the client and an 
+asynchronous send function which returns only when the transmit ack (tx_ack) is received.
 
-It exposes an async API for receiving all messages for the client
-and an asynchronous send function which returns only when the transmit ack is
-received.
+The `client` feature provides a Tokio-based runtime which handles the UDP and Semtech UDP protocol details, such as ACKs.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Semtech UDP provides serialization and deserialization of packets complying with
 
 The `server` feature provides a Tokio-based runtime which handles the UDP and Semtech GWMP UDP protocol details, such as
 ACKs and keeping track of client addresses. It exposes an async API for receiving all messages for the client and an 
-asynchronous send function which returns only when the transmit ack (tx_ack) is received.
+asynchronous send function which returns only when the transmit ack (tx_ack) is received
 
 The `client` feature provides a Tokio-based runtime which handles the UDP and Semtech UDP protocol details, such as ACKs.

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -2,6 +2,7 @@ use semtech_udp::{
     pull_resp,
     server_runtime::{Event, UdpRuntime},
     StringOrNum,
+    CodingRate,
 };
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -43,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     powe: 27,
                     modu: "LORA".to_string(),
                     datr: "SF8BW500".to_string(),
-                    codr: "4/5".to_string(),
+                    codr: CodingRate::_4_5,
                     ipol: true,
                     size,
                     data,

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -30,9 +30,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Event::PacketReceived(rxpk, gateway_mac) => {
                 println!("{:?}", rxpk);
 
-                let buffer = [1, 2, 3, 4];
-                let size = buffer.len() as u64;
-                let data = base64::encode(buffer);
+                let data = vec![1, 2, 3, 4];
+                let size = data.len() as u64;
                 let tmst = StringOrNum::N(rxpk.get_timestamp() + 1_000_000);
 
                 let txpk = pull_resp::TxPk {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,8 +1,7 @@
 use semtech_udp::{
     pull_resp,
     server_runtime::{Event, UdpRuntime},
-    StringOrNum,
-    CodingRate,
+    CodingRate, DataRate, Modulation, StringOrNum,
 };
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -42,8 +41,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     freq: 902.800_000,
                     rfch: 0,
                     powe: 27,
-                    modu: "LORA".to_string(),
-                    datr: "SF8BW500".to_string(),
+                    modu: Modulation::LORA,
+                    datr: DataRate::default(),
                     codr: CodingRate::_4_5,
                     ipol: true,
                     size,

--- a/examples/server_split.rs
+++ b/examples/server_split.rs
@@ -1,7 +1,7 @@
 use semtech_udp::{
     pull_resp,
     server_runtime::{Event, UdpRuntime},
-    MacAddress, StringOrNum,
+    MacAddress, StringOrNum, CodingRate
 };
 use std::net::SocketAddr;
 use structopt::StructOpt;
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 powe: cli.power as u64,
                 modu: "LORA".to_string(),
                 datr: cli.data_rate.clone(),
-                codr: "4/5".to_string(),
+                codr: CodingRate::_4_5,
                 ipol: cli.polarization_inversion,
                 size,
                 data,

--- a/examples/server_split.rs
+++ b/examples/server_split.rs
@@ -1,7 +1,7 @@
 use semtech_udp::{
     pull_resp,
     server_runtime::{Event, UdpRuntime},
-    MacAddress, StringOrNum, CodingRate
+    Bandwidth, CodingRate, DataRate, MacAddress, Modulation, SpreadingFactor, StringOrNum,
 };
 use std::net::SocketAddr;
 use structopt::StructOpt;
@@ -39,8 +39,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 freq: cli.frequency,
                 rfch: 0,
                 powe: cli.power as u64,
-                modu: "LORA".to_string(),
-                datr: cli.data_rate.clone(),
+                modu: Modulation::LORA,
+                datr: DataRate::new(cli.spreading_factor.clone(), cli.bandwidth.clone()),
                 codr: CodingRate::_4_5,
                 ipol: cli.polarization_inversion,
                 size,
@@ -121,9 +121,13 @@ pub struct Opt {
     #[structopt(long, default_value = "868.1")]
     frequency: f64,
 
-    /// Data rate (Spreading Factor / Bandwidth)
-    #[structopt(long, default_value = "SF12BW125")]
-    data_rate: String,
+    /// Spreading Factor (eg: SF12)
+    #[structopt(long, default_value = "SF12")]
+    spreading_factor: SpreadingFactor,
+
+    /// Bandwdith (eg: BW125)
+    #[structopt(long, default_value = "BW125")]
+    bandwidth: Bandwidth,
 
     /// Polarization inversion (set true when sending to devices)
     #[structopt(long)]

--- a/examples/server_split.rs
+++ b/examples/server_split.rs
@@ -28,9 +28,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut first_shot = true;
         while cli.delay != 0 || first_shot {
             first_shot = false;
-            let buffer = vec![0; cli.length];
-            let size = buffer.len() as u64;
-            let data = base64::encode(buffer);
+            let data = vec![0; cli.length];
+            let size = data.len() as u64;
             let tmst = StringOrNum::N(0);
 
             let txpk = pull_resp::TxPk {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate arrayref;
+
 mod packet;
 pub use packet::*;
 

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -1,6 +1,10 @@
 use num_enum::TryFromPrimitive;
+use serde::{Deserialize, Serialize};
 use std::error::Error as stdError;
 use std::fmt;
+
+mod types;
+pub use types::*;
 
 const PROTOCOL_VERSION: u8 = 2;
 
@@ -32,7 +36,6 @@ pub enum Identifier {
     PullAck = 4,
     TxAck = 5,
 }
-use serde::{Deserialize, Serialize};
 
 pub mod pull_ack;
 pub mod pull_data;

--- a/src/packet/parser.rs
+++ b/src/packet/parser.rs
@@ -41,6 +41,7 @@ impl Parser for Packet {
                     Identifier::PushData => {
                         let gateway_mac = gateway_mac(&buffer[..PACKET_PAYLOAD_START]);
                         let json_str = std::str::from_utf8(&buffer[PACKET_PAYLOAD_START..])?;
+
                         let data = serde_json::from_str(json_str)?;
 
                         push_data::Packet {

--- a/src/packet/pull_resp.rs
+++ b/src/packet/pull_resp.rs
@@ -11,8 +11,8 @@ Bytes  | Function
 4-end  | JSON object, starting with {, ending with }, see section 6
  */
 use super::{
-    tx_ack, write_preamble, Error as PktError, Identifier, MacAddress, SerializablePacket,
-    StringOrNum,
+    tx_ack, write_preamble, CodingRate, DataRate, Error as PktError, Identifier, MacAddress,
+    Modulation, SerializablePacket, StringOrNum,
 };
 use serde::{Deserialize, Serialize};
 use std::io::{Cursor, Write};
@@ -93,18 +93,18 @@ pub struct TxPk {
     pub tmst: StringOrNum, // Send packet on a certain timestamp value (will ignore time)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tmms: Option<StringOrNum>, // Send packet at a certain GPS time (GPS synchronization required)
-    pub freq: f64,    // TX central frequency in MHz (unsigned float, Hz precision)
-    pub rfch: u64,    // Concentrator "RF chain" used for TX (unsigned integer)
-    pub powe: u64,    // TX output power in dBm (unsigned integer, dBm precision)
-    pub modu: String, // Modulation identifier "LORA" or "FSK"
-    pub datr: String, // LoRa datarate identifier (eg. SF12BW500)
-    pub codr: String, // LoRa ECC coding rate identifier
+    pub freq: f64,        // TX central frequency in MHz (unsigned float, Hz precision)
+    pub rfch: u64,        // Concentrator "RF chain" used for TX (unsigned integer)
+    pub powe: u64,        // TX output power in dBm (unsigned integer, dBm precision)
+    pub modu: Modulation, // Modulation identifier "LORA" or "FSK"
+    pub datr: DataRate,   // LoRa datarate identifier (eg. SF12BW500)
+    pub codr: CodingRate, // LoRa ECC coding rate identifier
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fdev: Option<u64>, //FSK frequency deviation (unsigned integer, in Hz)
-    pub ipol: bool,   // Lora modulation polarization inversion
+    pub ipol: bool,       // Lora modulation polarization inversion
     pub prea: Option<u64>, // RF preamble size (unsigned integer)
-    pub size: u64,    // RF packet payload size in bytes (unsigned integer)
-    pub data: String, // Base64 encoded RF packet payload, padding optional
+    pub size: u64,        // RF packet payload size in bytes (unsigned integer)
+    pub data: String,     // Base64 encoded RF packet payload, padding optional
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ncrc: Option<bool>, // If true, disable the CRC of the physical layer (optional)
 }

--- a/src/packet/pull_resp.rs
+++ b/src/packet/pull_resp.rs
@@ -104,7 +104,8 @@ pub struct TxPk {
     pub ipol: bool,       // Lora modulation polarization inversion
     pub prea: Option<u64>, // RF preamble size (unsigned integer)
     pub size: u64,        // RF packet payload size in bytes (unsigned integer)
-    pub data: String,     // Base64 encoded RF packet payload, padding optional
+    #[serde(with = "crate::packet::types::base64")]
+    pub data: Vec<u8>, // Base64 encoded RF packet payload, padding optional
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ncrc: Option<bool>, // If true, disable the CRC of the physical layer (optional)
 }

--- a/src/packet/push_data.rs
+++ b/src/packet/push_data.rs
@@ -44,7 +44,7 @@ impl Packet {
         let rxpk = vec![RxPk::V1(RxPkV1 {
             chan: 0,
             codr: CodingRate::_4_5,
-            data: "AA=".to_string(),
+            data: vec![0, 0],
             datr: DataRate::default(),
             freq: 902.800_000,
             lsnr: -15.0,
@@ -98,7 +98,8 @@ data | string | Base64 encoded RF packet payload, padded
 pub struct RxPkV1 {
     pub chan: u64,
     pub codr: CodingRate,
-    pub data: String,
+    #[serde(with = "crate::packet::types::base64")]
+    pub data: Vec<u8>,
     pub datr: DataRate,
     pub freq: f64,
     pub lsnr: f32,
@@ -145,7 +146,8 @@ pub struct RxPkV2 {
     pub aesk: usize,
     pub brd: usize,
     pub codr: CodingRate,
-    pub data: String,
+    #[serde(with = "crate::packet::types::base64")]
+    pub data: Vec<u8>,
     pub datr: DataRate,
     pub freq: f64,
     pub jver: usize,
@@ -227,8 +229,8 @@ impl RxPk {
         get_field!(self, freq)
     }
 
-    pub fn get_data(&self) -> String {
-        get_field!(self, data).clone()
+    pub fn get_data(&self) -> &Vec<u8> {
+        get_field!(self, data)
     }
 
     pub fn get_timestamp(&self) -> &u64 {

--- a/src/packet/types.rs
+++ b/src/packet/types.rs
@@ -1,0 +1,93 @@
+use serde::{Deserialize, Serialize};
+
+pub use data_rate::*;
+
+pub mod data_rate {
+    use serde::de::IntoDeserializer;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Debug, Clone, Default)]
+    pub struct DataRate {
+        pub spreading_factor: SpreadingFactor,
+        pub bandwidth: Bandwidth,
+    }
+
+    impl Serialize for DataRate {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut str = String::new();
+            str.push_str(&format!("{:?}", self.spreading_factor));
+            str.push_str(&format!("{:?}", self.bandwidth));
+            serializer.serialize_str(&str)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for DataRate {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let s = <&str>::deserialize(deserializer)?;
+            let (sf_s, bw_s) = if s.len() > 8 {
+                (&s[..4], &s[4..])
+            } else {
+                (&s[..3], &s[3..])
+            };
+
+            Ok(DataRate {
+                bandwidth: Bandwidth::deserialize(bw_s.into_deserializer())?,
+                spreading_factor: SpreadingFactor::deserialize(sf_s.into_deserializer())?,
+            })
+        }
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+    pub enum SpreadingFactor {
+        SF7,
+        SF8,
+        SF9,
+        SF10,
+        SF11,
+        SF12,
+    }
+
+    impl Default for SpreadingFactor {
+        fn default() -> Self {
+            SpreadingFactor::SF7
+        }
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+    pub enum Bandwidth {
+        BW125,
+        BW250,
+        BW500,
+    }
+
+    impl Default for Bandwidth {
+        fn default() -> Self {
+            Bandwidth::BW250
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum CodingRate {
+    #[serde(rename(serialize = "4/5", deserialize = "4/5"))]
+    _4_5,
+    #[serde(rename(serialize = "4/6", deserialize = "4/6"))]
+    _4_6,
+    #[serde(rename(serialize = "4/7", deserialize = "4/7"))]
+    _4_7,
+    #[serde(rename(serialize = "4/8", deserialize = "4/8"))]
+    _4_8,
+    OFF,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum Modulation {
+    LORA,
+    FSK,
+}

--- a/src/packet/types.rs
+++ b/src/packet/types.rs
@@ -144,3 +144,23 @@ pub enum Modulation {
     LORA,
     FSK,
 }
+
+pub(crate) mod base64 {
+    extern crate base64;
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&base64::encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+        base64::decode(s).map_err(de::Error::custom)
+    }
+}

--- a/src/packet/types.rs
+++ b/src/packet/types.rs
@@ -5,6 +5,7 @@ pub use data_rate::*;
 pub mod data_rate {
     use serde::de::IntoDeserializer;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::str::FromStr;
 
     #[derive(Debug, Clone, Default)]
     pub struct DataRate {
@@ -12,6 +13,14 @@ pub mod data_rate {
         pub bandwidth: Bandwidth,
     }
 
+    impl DataRate {
+        pub fn new(spreading_factor: SpreadingFactor, bandwidth: Bandwidth) -> DataRate {
+            DataRate {
+                spreading_factor,
+                bandwidth,
+            }
+        }
+    }
     impl Serialize for DataRate {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -53,6 +62,22 @@ pub mod data_rate {
         SF12,
     }
 
+    impl FromStr for SpreadingFactor {
+        type Err = ParseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            match s {
+                "SF7" => Ok(SpreadingFactor::SF7),
+                "SF8" => Ok(SpreadingFactor::SF8),
+                "SF9" => Ok(SpreadingFactor::SF9),
+                "SF10" => Ok(SpreadingFactor::SF10),
+                "SF11" => Ok(SpreadingFactor::SF11),
+                "SF12" => Ok(SpreadingFactor::SF12),
+                _ => Err(ParseError::InvalidSpreadingFactor),
+            }
+        }
+    }
+
     impl Default for SpreadingFactor {
         fn default() -> Self {
             SpreadingFactor::SF7
@@ -66,9 +91,37 @@ pub mod data_rate {
         BW500,
     }
 
+    impl FromStr for Bandwidth {
+        type Err = ParseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            match s {
+                "BW125" => Ok(Bandwidth::BW125),
+                "BW250" => Ok(Bandwidth::BW250),
+                "BW500" => Ok(Bandwidth::BW500),
+                _ => Err(ParseError::InvalidBandwidth),
+            }
+        }
+    }
+
     impl Default for Bandwidth {
         fn default() -> Self {
             Bandwidth::BW250
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum ParseError {
+        InvalidSpreadingFactor,
+        InvalidBandwidth,
+    }
+    impl std::fmt::Display for ParseError {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            let msg = match self {
+                ParseError::InvalidSpreadingFactor => "Invalid spreading factor input",
+                ParseError::InvalidBandwidth => "Invalid bandwidth input",
+            };
+            write!(f, "{}", msg)
         }
     }
 }

--- a/src/packet/types.rs
+++ b/src/packet/types.rs
@@ -4,10 +4,10 @@ pub use data_rate::*;
 
 pub mod data_rate {
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+    use std::cmp::PartialEq;
     use std::str::FromStr;
     use std::string::ToString;
-
-    #[derive(Debug, Clone, Default)]
+    #[derive(Debug, Clone, Default, PartialEq)]
     pub struct DataRate(SpreadingFactor, Bandwidth);
 
     impl DataRate {
@@ -146,6 +146,36 @@ pub mod data_rate {
                 ParseError::InvalidBandwidth => "Invalid bandwidth input",
             };
             write!(f, "{}", msg)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        // Note this useful idiom: importing names from outer (for mod tests) scope.
+        use super::*;
+
+        #[test]
+        fn test_to_string_sf7() {
+            let datarate = DataRate(SpreadingFactor::SF7, Bandwidth::BW500);
+            assert_eq!(datarate.to_string(), "SF7BW500")
+        }
+
+        #[test]
+        fn test_to_string_sf10() {
+            let datarate = DataRate(SpreadingFactor::SF10, Bandwidth::BW125);
+            assert_eq!(datarate.to_string(), "SF10BW125")
+        }
+
+        #[test]
+        fn test_from_str_sf10() {
+            let datarate = DataRate::from_str("SF10BW125").unwrap();
+            assert_eq!(datarate, DataRate(SpreadingFactor::SF10, Bandwidth::BW125))
+        }
+
+        #[test]
+        fn test_from_str_sf7() {
+            let datarate = DataRate::from_str("SF7BW500").unwrap();
+            assert_eq!(datarate, DataRate(SpreadingFactor::SF7, Bandwidth::BW500))
         }
     }
 }

--- a/src/packet/types.rs
+++ b/src/packet/types.rs
@@ -8,40 +8,40 @@ pub mod data_rate {
     use std::string::ToString;
 
     #[derive(Debug, Clone, Default)]
-    pub struct DataRate {
-        pub spreading_factor: SpreadingFactor,
-        pub bandwidth: Bandwidth,
-    }
+    pub struct DataRate(SpreadingFactor, Bandwidth);
 
     impl DataRate {
         pub fn new(spreading_factor: SpreadingFactor, bandwidth: Bandwidth) -> DataRate {
-            DataRate {
-                spreading_factor,
-                bandwidth,
-            }
+            DataRate(spreading_factor, bandwidth)
+        }
+        pub fn spreading_factor(&self) -> &SpreadingFactor {
+            &self.0
+        }
+        pub fn bandwidth(&self) -> &Bandwidth {
+            &self.1
         }
     }
 
     impl FromStr for DataRate {
         type Err = ParseError;
         fn from_str(s: &str) -> Result<Self, Self::Err> {
-            let (spreading, bandwidth) = if s.len() > 8 {
+            let (sf, bw) = if s.len() > 8 {
                 (&s[..4], &s[4..])
             } else {
                 (&s[..3], &s[3..])
             };
 
-            Ok(DataRate {
-                bandwidth: Bandwidth::from_str(bandwidth)?,
-                spreading_factor: SpreadingFactor::from_str(spreading)?,
-            })
+            Ok(DataRate(
+                SpreadingFactor::from_str(sf)?,
+                Bandwidth::from_str(bw)?,
+            ))
         }
     }
 
     impl ToString for DataRate {
         fn to_string(&self) -> String {
-            let mut output = self.spreading_factor.to_string();
-            output.push_str(&self.bandwidth.to_string());
+            let mut output = self.spreading_factor().to_string();
+            output.push_str(&self.bandwidth().to_string());
             output
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -141,23 +141,6 @@ fn test_timed_send() {
 
 #[test]
 fn new_packet() {
-    let rxpk = push_data::RxPkV1 {
-        chan: 0,
-        codr: CodingRate::_4_5,
-        data: vec![0, 0],
-        datr: DataRate::default(),
-        freq: 902.800_000,
-        lsnr: -15.0,
-        modu: Modulation::LORA,
-        rfch: 0,
-        rssi: -80,
-        size: 12,
-        stat: push_data::CRC::OK,
-        tmst: 12,
-    };
-
-    println!("{:?}", serde_json::to_string(&rxpk));
-
     let recv = [
         2, 159, 48, 0, 0, 128, 0, 0, 160, 0, 102, 31, 123, 34, 114, 120, 112, 107, 34, 58, 91, 123,
         34, 116, 109, 115, 116, 34, 58, 52, 50, 48, 50, 56, 55, 57, 48, 56, 52, 44, 34, 116, 105,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -138,3 +138,58 @@ fn test_timed_send() {
         assert!(false);
     }
 }
+
+#[test]
+fn new_packet() {
+    let rxpk = push_data::RxPkV1 {
+        chan: 0,
+        codr: CodingRate::_4_5,
+        data: "AA=".to_string(),
+        datr: DataRate::default(),
+        freq: 902.800_000,
+        lsnr: -15.0,
+        modu: Modulation::LORA,
+        rfch: 0,
+        rssi: -80,
+        size: 12,
+        stat: push_data::CRC::OK,
+        tmst: 12,
+    };
+
+    println!("{:?}", serde_json::to_string(&rxpk));
+
+    let recv = [
+        2, 159, 48, 0, 0, 128, 0, 0, 160, 0, 102, 31, 123, 34, 114, 120, 112, 107, 34, 58, 91, 123,
+        34, 116, 109, 115, 116, 34, 58, 52, 50, 48, 50, 56, 55, 57, 48, 56, 52, 44, 34, 116, 105,
+        109, 101, 34, 58, 34, 50, 48, 50, 49, 45, 48, 50, 45, 48, 51, 84, 49, 57, 58, 48, 51, 58,
+        52, 54, 46, 53, 48, 48, 51, 52, 57, 90, 34, 44, 34, 116, 109, 109, 115, 34, 58, 49, 50, 57,
+        54, 52, 49, 52, 50, 52, 52, 53, 48, 48, 44, 34, 99, 104, 97, 110, 34, 58, 51, 44, 34, 114,
+        102, 99, 104, 34, 58, 48, 44, 34, 102, 114, 101, 113, 34, 58, 57, 48, 52, 46, 53, 48, 48,
+        48, 48, 48, 44, 34, 115, 116, 97, 116, 34, 58, 45, 49, 44, 34, 109, 111, 100, 117, 34, 58,
+        34, 76, 79, 82, 65, 34, 44, 34, 100, 97, 116, 114, 34, 58, 34, 83, 70, 49, 48, 66, 87, 49,
+        50, 53, 34, 44, 34, 99, 111, 100, 114, 34, 58, 34, 52, 47, 53, 34, 44, 34, 108, 115, 110,
+        114, 34, 58, 45, 49, 53, 46, 53, 44, 34, 114, 115, 115, 105, 34, 58, 45, 49, 49, 53, 44,
+        34, 115, 105, 122, 101, 34, 58, 49, 54, 44, 34, 100, 97, 116, 97, 34, 58, 34, 81, 77, 114,
+        111, 67, 111, 110, 100, 73, 71, 54, 106, 57, 84, 52, 81, 99, 82, 75, 100, 57, 119, 61, 61,
+        34, 125, 93, 125,
+    ];
+
+    let packet = Packet::parse(&recv).unwrap();
+
+    if let Packet::Up(Up::PushData(packet)) = packet {
+        let _packet_first_read = Packet::parse(&recv).unwrap();
+
+        let mut buffer_first = [0; 512];
+        let written_first = packet.serialize(&mut buffer_first).unwrap();
+
+        let packet_second_read = Packet::parse(&buffer_first[..written_first as usize]).unwrap();
+        if let Packet::Up(Up::PushData(packet_second_read)) = packet_second_read {
+            let mut buffer_second = [0; 512];
+            let _written_second = packet_second_read.serialize(&mut buffer_second).unwrap();
+        } else {
+            assert!(false);
+        }
+    } else {
+        assert!(false);
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -117,7 +117,7 @@ use crate::packet::StringOrNum;
 #[test]
 fn test_immediate_send() {
     use crate::packet::pull_resp::TxPk;
-    let json = "{\"codr\":\"4/5\",\"data\":\"QDDaAAHUbYkmAGY3AFAvfpbHJeCeuDu3xbCCHeg7YPOUJOfBCSc4Y3LtT4aToTGl9AYK4+NiALvTgey0M4ZJzh43vLaaXzFHko0jlb0CVeNgAtbTsAttQ\",\"datr\":\"SF10BW125\",\"freq\":904.1,\"imme\":true,\"ipol\":false,\"modu\":\"LORA\",\"powe\":27,\"rfch\":0,\"size\":87,\"tmst\":\"immediate\"}";
+    let json = "{\"codr\":\"4/5\",\"data\":\"IHLF2EA+n8BFY1vrCU1k/Vg=\",\"datr\":\"SF10BW125\",\"freq\":904.1,\"imme\":true,\"ipol\":false,\"modu\":\"LORA\",\"powe\":27,\"rfch\":0,\"size\":87,\"tmst\":\"immediate\"}";
 
     let txpk: TxPk = serde_json::from_str(json).unwrap();
     if let StringOrNum::S(_) = txpk.tmst {
@@ -144,7 +144,7 @@ fn new_packet() {
     let rxpk = push_data::RxPkV1 {
         chan: 0,
         codr: CodingRate::_4_5,
-        data: "AA=".to_string(),
+        data: vec![0, 0],
         datr: DataRate::default(),
         freq: 902.800_000,
         lsnr: -15.0,


### PR DESCRIPTION
A deserialization error on `stat` caused me to revisit the type definitions in RxPk and TxPk. While a simple fix of changing the type to `u8` would have sufficed, it seemed time to implement some real types.

In particular, this PR implements the following fields in the GWMP Json payloads into more specific types than generic integers or Strings
```
    modu: Modulation, // Modulation identifier "LORA" or "FSK"
    datr: DataRate,   // LoRa datarate identifier (eg. SF12BW500)
    codr: CodingRate, // LoRa ECC coding rate identifier
    stat: CRC, // CRC status: 1 = OK, -1 = fail, 0 = no CRC
    data: Vec<u8> // is represented in base64 in the JSON
```

Most of the implementations are pretty straightforward except for DataRate. In order to have a relatively nice Rust type, the single string ("SF12BW500") gets parsed into a struct:
```
    #[derive(Debug, Clone, Default)]
    pub struct DataRate {
        pub spreading_factor: SpreadingFactor,
        pub bandwidth: Bandwidth,
    }

    pub enum SpreadingFactor {
        SF7,
        SF8,
        SF9,
        SF10,
        SF11,
        SF12,
    }

    pub enum Bandwidth {
        BW125,
        BW250,
        BW500,
    }
```

