### PR TITLE
Bug Fixes: no automatic TxAck from client_runtime and make Downlink struct safely clonable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ required-features = ["client", "server"]
 [dependencies]
 arrayref = "0"
 base64 = "0"
+log = "0"
 num_enum = "0"
 rand = "0"
 serde = { version = "1", default-features = false,  features = ["derive"] }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -54,9 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Semtech GWMP over UDP Client Example",
-)]
+#[structopt(name = "Semtech GWMP over UDP Client Example")]
 pub struct Opt {
     /// dial out port
     #[structopt(short, long, default_value = "1600")]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -42,6 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         match msg {
             semtech_udp::Packet::Down(down) => {
                 if let semtech_udp::Down::PullResp(packet) = down {
+                    // it is the client's responsibility to ack the tx request
                     let ack =
                         (*packet).into_ack_for_gateway(semtech_udp::MacAddress::new(&mac_address));
                     sender.send(ack.into()).await?;

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -56,7 +56,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "Semtech GWMP over UDP Client Example",
-    about = "LoRaWAN test device utility"
 )]
 pub struct Opt {
     /// dial out port

--- a/src/packet/parser.rs
+++ b/src/packet/parser.rs
@@ -70,7 +70,7 @@ impl Parser for Packet {
                     Identifier::PushAck => push_ack::Packet { random_token }.into(),
                     Identifier::PullAck => pull_ack::Packet { random_token }.into(),
                     Identifier::PullResp => {
-                        let json_str = std::str::from_utf8(&buffer)?;
+                        let json_str = std::str::from_utf8(buffer)?;
                         let data = serde_json::from_str(json_str)?;
                         pull_resp::Packet { random_token, data }.into()
                     }

--- a/src/packet/pull_resp.rs
+++ b/src/packet/pull_resp.rs
@@ -133,7 +133,7 @@ impl SerializablePacket for Packet {
         let mut w = Cursor::new(buffer);
         write_preamble(&mut w, self.random_token)?;
         w.write_all(&[Identifier::PullResp as u8])?;
-        w.write_all(&serde_json::to_string(&self.data)?.as_bytes())?;
+        w.write_all(serde_json::to_string(&self.data)?.as_bytes())?;
         Ok(w.position())
     }
 }

--- a/src/packet/push_data.rs
+++ b/src/packet/push_data.rs
@@ -333,8 +333,8 @@ impl SerializablePacket for Packet {
         let mut w = Cursor::new(buffer);
         write_preamble(&mut w, self.random_token)?;
         w.write_all(&[Identifier::PushData as u8])?;
-        w.write_all(&self.gateway_mac.bytes())?;
-        w.write_all(&serde_json::to_string(&self.data)?.as_bytes())?;
+        w.write_all(self.gateway_mac.bytes())?;
+        w.write_all(serde_json::to_string(&self.data)?.as_bytes())?;
         Ok(w.position())
     }
 }

--- a/src/packet/tx_ack.rs
+++ b/src/packet/tx_ack.rs
@@ -38,8 +38,8 @@ impl SerializablePacket for Packet {
         let mut w = Cursor::new(buffer);
         write_preamble(&mut w, self.random_token)?;
         w.write_all(&[Identifier::TxAck as u8])?;
-        w.write_all(&self.gateway_mac.bytes())?;
-        w.write_all(&serde_json::to_string(&self.data)?.as_bytes())?;
+        w.write_all(self.gateway_mac.bytes())?;
+        w.write_all(serde_json::to_string(&self.data)?.as_bytes())?;
         Ok(w.position())
     }
 }

--- a/src/packet/types.rs
+++ b/src/packet/types.rs
@@ -62,7 +62,7 @@ pub mod data_rate {
             D: Deserializer<'de>,
         {
             let s = <&str>::deserialize(deserializer)?;
-            DataRate::from_str(&s).map_err(de::Error::custom)
+            DataRate::from_str(s).map_err(de::Error::custom)
         }
     }
 

--- a/src/server_runtime/mod.rs
+++ b/src/server_runtime/mod.rs
@@ -229,9 +229,8 @@ impl UdpRuntime {
 
 impl UdpRx {
     pub async fn run(self) -> Result {
+        let mut buf = vec![0u8; 1024];
         loop {
-            let mut buf = vec![0u8; 1024];
-
             match self.socket_receiver.recv_from(&mut buf).await {
                 Err(e) => return Err(e.into()),
                 Ok((n, src)) => {

--- a/src/server_runtime/mod.rs
+++ b/src/server_runtime/mod.rs
@@ -247,7 +247,7 @@ impl UdpRx {
                     if let Some(packet) = packet {
                         match packet {
                             Packet::Up(packet) => {
-                                //echo all packets to client
+                                // echo all packets to client
                                 self.internal_sender
                                     .send(InternalEvent::RawPacket(packet.clone()))
                                     .await?;

--- a/src/server_runtime/mod.rs
+++ b/src/server_runtime/mod.rs
@@ -247,8 +247,6 @@ impl UdpRx {
                     if let Some(packet) = packet {
                         match packet {
                             Packet::Up(packet) => {
-                                eprintln!("Received {:?}", packet);
-
                                 //echo all packets to client
                                 self.internal_sender
                                     .send(InternalEvent::RawPacket(packet.clone()))


### PR DESCRIPTION
Bug Fixes: 
* no automatic TxAck from client_runtime: the client runtime was providing ACKs but it is the client's responsibility to take the transmit request and to ACK. While there's not much of an API for it yet, this allow for NACKs.
* make Downlink struct safely clonable: the downlink struct previously received its `random_token` upon construction. During a clone, the `random_token` would exist twice, making it not so random and would make parsing TxAcks confusing.

Logs are added and last prints removed.