### PR TITLE
Improvements for spotty connections

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -33,6 +33,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     while let Some(event) = downlink_request_receiver.recv().await {
         match event {
+            Event::LostConnection => {
+                println!("Lost connection to GWMP client");
+            }
+            Event::Reconnected => {
+                println!("Reconnected to GWMP client");
+            }
             Event::DownlinkRequest(downlink_request) => downlink_request.ack().await?,
             Event::UnableToParseUdpFrame(parse_error, _buffer) => {
                 println!("Error parsing UDP frame {}", parse_error)

--- a/examples/gwmp-mux.rs
+++ b/examples/gwmp-mux.rs
@@ -274,6 +274,15 @@ async fn run_client_instance_handle_downlink(
                     "Error parsing frame from {mac}: {parse_error}, {buffer:?}"
                 );
             }
+            ClientEvent::LostConnection => {
+                warn!(
+                    &logger,
+                    "Lost connection to GWMP client {mac}. Dropping frames."
+                )
+            }
+            ClientEvent::Reconnected => {
+                warn!(&logger, "Reconnected to GWMP client {mac}")
+            }
         }
     }
     Ok(())

--- a/src/client_runtime/mod.rs
+++ b/src/client_runtime/mod.rs
@@ -251,13 +251,13 @@ impl Tx {
                     Ok(_) => {
                         if !connected {
                             connected = true;
-                            self.client_sender.send(Event::Reconnected);
+                            self.client_sender.send(Event::Reconnected).await?;
                         }
                     }
                     Err(_) => {
                         if connected {
                             connected = false;
-                            self.client_sender.send(Event::LostConnection);
+                            self.client_sender.send(Event::LostConnection).await?;
                         }
                     }
                 }


### PR DESCRIPTION
client_runtime no longer backs off of writes and instead informs client of lost connections and writes continuously. this avoids a backed up queue and there was no benefit to backing off.

server_runtime spawns off writing to a client so as to not allow a slow client to back up writing to faster clients.