### PR TITLE
PUSH_DATA: don't serialize `rssis` when none

### DIFF
--- a/src/packet/push_data.rs
+++ b/src/packet/push_data.rs
@@ -199,6 +199,7 @@ pub struct RSig {
     pub ant: usize,
     pub chan: u64,
     pub rssic: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rssis: Option<i32>,
     pub lsnr: f32,
     pub etime: Option<String>,


### PR DESCRIPTION
`rssis` is optional and only available when the gateway supports it.
When not available, do not serialize it (as JSON "null") otherwise it
makes Erlang code to crash.

Code crash has been observed here, when `gwmp-mux` forwards a packet
containing `{"rssis": null}`:
https://github.com/helium/miner/blob/andymck/poc-grpc/src/miner_lora_light.erl#L482
```erlang
erlang:trunc(packet_rssi(Packet, UseRSSIS)),
```

with trace:
[error] <0.4614.7>@miner_lora_light:handle_packets:482 gen_server miner_lora_light terminated with reason: bad argument in call to erlang:trunc(null) in miner_lora_light:handle_packets/4 line 482
[error] <0.4614.7>@miner_lora_light:handle_packets:482 CRASH REPORT Process miner_lora_light with 0 neighbours crashed with reason: bad argument in call to erlang:trunc(null) in miner_lora_light:handle_packets/4 line 482

This fixes the crash.