### PR TITLE
PUSH_DATA: Fix SNR value for negative rsig.lsnr

### DIFF
--- a/src/packet/push_data.rs
+++ b/src/packet/push_data.rs
@@ -255,7 +255,7 @@ impl RxPk {
                 .iter()
                 // truncate the decimal when choosing best LSNR value
                 .fold(-150.0, |max, x| {
-                    if (max as u32) < (x.lsnr as u32) {
+                    if (max as i32) < (x.lsnr as i32) {
                         x.lsnr
                     } else {
                         max


### PR DESCRIPTION
We discovered that, when a GWMPv2 `rxpk` is received with negative
`rsig.lsnr` value, `RxPk.get_snr()` was always returning -150.0.
This fix the issue, by casting to `i32` instead of `u32`.