### PR TITLE
TxPk for immediate send may omit tmst entirely

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let txpk = pull_resp::TxPk {
                     imme: false,
-                    tmst,
+                    tmst: Some(tmst),
                     freq: 902.800_000,
                     rfch: 0,
                     powe: 27,

--- a/examples/server_split.rs
+++ b/examples/server_split.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let txpk = pull_resp::TxPk {
                     imme: true,
-                    tmst,
+                    tmst: Some(tmst),
                     freq: cli.frequency,
                     rfch: 0,
                     powe: cli.power as u64,

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -93,7 +93,7 @@ fn write_preamble(w: &mut Cursor<&mut [u8]>, token: u16) -> Result {
     Ok(w.write_all(&[PROTOCOL_VERSION, (token >> 8) as u8, token as u8])?)
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum StringOrNum {
     S(String),

--- a/src/packet/push_data.rs
+++ b/src/packet/push_data.rs
@@ -371,3 +371,37 @@ impl Packet {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn check_given_snr(data: Data, expected_snr: f32) {
+        if let Some(mut rxpk) = data.rxpk {
+            assert_eq!(rxpk.len(), 1);
+            if let Some(rxpk) = rxpk.pop() {
+                assert_eq!(rxpk.get_snr(), expected_snr)
+            } else {
+                // rxpk is empty vector
+                assert!(false)
+            }
+        } else {
+            // rxpk is None
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn rxpk_positive_lsnr() {
+        let json = "{\"rxpk\":[{\"aesk\":0,\"brd\":263,\"codr\":\"4/5\",\"data\":\"QC65rwEA4w8CaH7LyGf/3+dxzrXkkfEsRCcXbFM=\",\"datr\":\"SF12BW125\",\"freq\":868.5,\"jver\":2,\"modu\":\"LORA\",\"rsig\":[{\"ant\":0,\"chan\":7,\"lsnr\":7.8,\"rssic\":-103}],\"size\":29,\"stat\":1,\"time\":\"2022-03-31T07:51:15.709338Z\",\"tmst\":445296860}]}";
+        let parsed: Data = serde_json::from_str(json).expect("Error parsing push_data::Data");
+        check_given_snr(parsed, 7.8);
+    }
+
+    #[test]
+    fn rxpk_negative_lsnr() {
+        let json = "{\"rxpk\":[{\"aesk\":0,\"brd\":261,\"codr\":\"4/5\",\"data\":\"QI8cACQA6iAD3TTei0kPKKyxBA==\",\"datr\":\"SF11BW125\",\"freq\":868.1,\"jver\":2,\"modu\":\"LORA\",\"rsig\":[{\"ant\":0,\"chan\":5,\"lsnr\":-3.5,\"rssic\":-120}],\"size\":19,\"stat\":1,\"time\":\"2022-03-31T07:51:12.631018Z\",\"tmst\":442218540}]}";
+        let parsed: Data = serde_json::from_str(json).expect("Error parsing push_data::Data");
+        check_given_snr(parsed, -3.5);
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -120,19 +120,28 @@ fn test_immediate_send() {
     let json = "{\"codr\":\"4/5\",\"data\":\"IHLF2EA+n8BFY1vrCU1k/Vg=\",\"datr\":\"SF10BW125\",\"freq\":904.1,\"imme\":true,\"ipol\":false,\"modu\":\"LORA\",\"powe\":27,\"rfch\":0,\"size\":87,\"tmst\":\"immediate\"}";
 
     let txpk: TxPk = serde_json::from_str(json).unwrap();
-    if let StringOrNum::S(_) = txpk.tmst {
+    if let Some(StringOrNum::S(_)) = txpk.tmst {
         assert!(true);
     } else {
         assert!(false);
     }
 }
+
+#[test]
+fn test_immediate_send_null_tmst() {
+    use crate::packet::pull_resp::TxPk;
+    let json = "{\"imme\":true,\"rfch\":0,\"powe\":27,\"ant\":0,\"brd\":0,\"freq\":869.525,\"modu\":\"LORA\",\"datr\":\"SF12BW125\",\"codr\":\"4/5\",\"ipol\":true,\"size\":15,\"data\":\"oL8/tACQAgABICUK5CYB\"}";
+    let txpk: TxPk = serde_json::from_str(json).unwrap();
+    assert!(txpk.is_immediate())
+}
+
 #[test]
 fn test_timed_send() {
     use crate::packet::pull_resp::TxPk;
     let json = "{\"codr\":\"4/5\",\"data\":\"IHLF2EA+n8BFY1vrCU1k/Vg=\",\"datr\":\"SF10BW500\",\"freq\":926.9000244140625,\"imme\":false,\"ipol\":true,\"modu\":\"LORA\",\"powe\":27,\"rfch\":0,\"size\":17,\"tmst\":727050748}";
 
     let txpk: TxPk = serde_json::from_str(json).unwrap();
-    if let StringOrNum::N(_) = txpk.tmst {
+    if let Some(StringOrNum::N(_)) = txpk.tmst {
         assert!(true);
     } else {
         assert!(false);


### PR DESCRIPTION
Some packet forwarders will omit the `tmst` field when a downlink is schedule for immediate transmit.

For example:
```
{"imme":true,"rfch":0,"powe":27,"ant":0,"brd":0,"freq":869.525,"modu":"LORA","datr":"SF12BW125","codr":"4/5","ipol":true,"size":15,"data":"oL8/tACQAgABICUK5CYB"}}
```

Previously, this would create an error: `JsonError: missing field tmst`. 

This PR makes the `tmst` field optional.

