### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,17 @@ name = "client"
 required-features = ["client"]
 
 [dependencies]
-arrayref = "0"
-base64 = "0"
+arrayref = "0.3"
+base64 = "0.13"
 macaddr = "1"
-num_enum = "0"
-rand = "0"
+num_enum = "0.5"
+rand = "0.8"
 serde = { version = "1", default-features = false,  features = ["derive"] }
 serde_json = "1"
-serde_repr = "0"
+serde_repr = "0.1"
 tokio = { version = "1", optional = true, features = ["rt", "net", "sync", "time", "macros"]}
 thiserror = "1"
-triggered  = "0"
+triggered  = "0.1"
 
 [dev-dependencies]
 structopt = { version = "0.3.2", default-features = false }


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.