### PR TITLE
Parse tmst in TxAck

### DIFF
--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -93,7 +93,7 @@ fn write_preamble(w: &mut Cursor<&mut [u8]>, token: u16) -> Result {
     Ok(w.write_all(&[PROTOCOL_VERSION, (token >> 8) as u8, token as u8])?)
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum StringOrNum {
     S(String),

--- a/src/packet/parser.rs
+++ b/src/packet/parser.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::tx_ack::TxPkNack;
+use crate::tx_ack::Data;
 use std::convert::TryFrom;
 
 const PROTOCOL_VERSION_INDEX: usize = 0;
@@ -80,7 +80,7 @@ impl Parser for Packet {
                             if buffer.len() == PACKET_PAYLOAD_START + 1
                                 && buffer[PACKET_PAYLOAD_START] == 0
                             {
-                                TxPkNack::default()
+                                Data::default()
                             } else {
                                 let json_str =
                                     std::str::from_utf8(&buffer[PACKET_PAYLOAD_START..])?;
@@ -93,7 +93,7 @@ impl Parser for Packet {
                                 })?
                             }
                         } else {
-                            TxPkNack::default()
+                            Data::default()
                         };
                         tx_ack::Packet {
                             random_token,

--- a/src/packet/pull_resp.rs
+++ b/src/packet/pull_resp.rs
@@ -28,7 +28,7 @@ impl Packet {
         tx_ack::Packet {
             gateway_mac,
             random_token: self.random_token,
-            data: tx_ack::TxPkNack::default(),
+            data: tx_ack::Data::default(),
         }
     }
 
@@ -40,7 +40,7 @@ impl Packet {
         tx_ack::Packet {
             gateway_mac,
             random_token: self.random_token,
-            data: super::tx_ack::TxPkNack::new_with_error(error),
+            data: super::tx_ack::Data::new_with_error(error),
         }
     }
 

--- a/src/packet/push_data.rs
+++ b/src/packet/push_data.rs
@@ -128,7 +128,7 @@ pub struct RxPkV1 {
     pub time: Option<String>,
 }
 
-#[derive(Debug, Serialize_repr, Deserialize_repr, Clone, PartialEq)]
+#[derive(Debug, Serialize_repr, Deserialize_repr, Clone, PartialEq, Eq)]
 #[repr(i8)]
 pub enum CRC {
     Disabled = 0,

--- a/src/packet/tx_ack.rs
+++ b/src/packet/tx_ack.rs
@@ -136,7 +136,7 @@ impl From<ErrorField> for Result<(), Error> {
 }
 
 use thiserror::Error;
-#[derive(Debug, Error, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Error {
     #[error("TxAck::Error::TOO_LATE")]
     TooLate,

--- a/src/packet/tx_ack.rs
+++ b/src/packet/tx_ack.rs
@@ -167,6 +167,7 @@ pub struct Data {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TxPkAck {
+    #[serde(skip_serializing_if = "Option::is_none")]
     tmst: Option<u32>,
     #[serde(flatten)]
     result: TxPkAckResult,
@@ -229,6 +230,7 @@ enum TxPkAckResult {
     },
     Warn {
         warn: ErrorField,
+        #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<i32>,
     },
 }

--- a/src/packet/tx_ack.rs
+++ b/src/packet/tx_ack.rs
@@ -160,13 +160,13 @@ pub enum Error {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Data {
-    txpk_ack: SubTxPkAck,
+    txpk_ack: TxPkAck,
 }
 
 impl Default for Data {
     fn default() -> Self {
         Data {
-            txpk_ack: SubTxPkAck::Error {
+            txpk_ack: TxPkAck::Error {
                 error: ErrorField::None,
             },
         }
@@ -176,12 +176,12 @@ impl Default for Data {
 impl Data {
     pub fn new_with_error(error: Error) -> Data {
         let txpk_ack = if let Error::InvalidTransmitPower(Some(v)) = error {
-            SubTxPkAck::Warn {
+            TxPkAck::Warn {
                 warn: ErrorField::from(Err(error)),
                 value: Some(v),
             }
         } else {
-            SubTxPkAck::Error {
+            TxPkAck::Error {
                 error: ErrorField::from(Err(error)),
             }
         };
@@ -190,11 +190,11 @@ impl Data {
 
     pub fn get_result(&self) -> Result<(), Error> {
         match &self.txpk_ack {
-            SubTxPkAck::Error { error } => {
+            TxPkAck::Error { error } => {
                 let res: Result<(), Error> = (*error).into();
                 res
             }
-            SubTxPkAck::Warn { warn, value } => {
+            TxPkAck::Warn { warn, value } => {
                 if let ErrorField::TxPower = warn {
                     Err(Error::InvalidTransmitPower(*value))
                 } else {
@@ -207,7 +207,7 @@ impl Data {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-enum SubTxPkAck {
+enum TxPkAck {
     Error {
         error: ErrorField,
     },

--- a/src/packet/types.rs
+++ b/src/packet/types.rs
@@ -7,7 +7,7 @@ pub mod data_rate {
     use std::cmp::PartialEq;
     use std::str::FromStr;
     use std::string::ToString;
-    #[derive(Debug, Clone, Default, PartialEq)]
+    #[derive(Debug, Clone, Default, PartialEq, Eq)]
     pub struct DataRate(SpreadingFactor, Bandwidth);
 
     impl DataRate {
@@ -66,7 +66,7 @@ pub mod data_rate {
         }
     }
 
-    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
     pub enum SpreadingFactor {
         SF7,
         SF8,
@@ -110,7 +110,7 @@ pub mod data_rate {
         }
     }
 
-    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
     pub enum Bandwidth {
         BW125,
         BW250,


### PR DESCRIPTION
As an extension to the existing JSON, the client may optionally indicate the `tmst` of a scheduled packet.

Where a success would typically look like this:
```json
{
	"txpk_ack": {"error": "NONE"}
}
```
It now _may_ looks like this:
```json
{
	"txpk_ack": {"error": "NONE", "tmst": 1234}
}
```

Note, the following frame is _not_ tolerated:
```json
{
	"txpk_ack": {"tmst": 1234}
}
```
It has been convention until now for packet forwarder to express `"error":"NONE"` upon success.

In addition, this PR clarifies the result of a TX_POWER warning. That is to say, a `txpk_ack` object that looks like this

```json
{ 
	"txpk_ack": { "warn" : "TX_POWER", "value" : 27 }
}
```

Was previously parsed into an `Error::InvalidTransmitPower(usize)`. However, this is merely a warning and the radio packet is expected to be sent, albeit at a lower transmit power. Therefore, we renamed the error to `Error::AdjustedTransmitPower(usize)`.

Meanwhile, `Error::InvalidTransmitPower(usize)` is maintained for `txpk_ack` objects that looks like this:
```json
{
	"txpk_ack": { "error" : "TX_POWER", "value" : 27 }
}
```

Note, the type is also extended to tolerate `tmst`, that is to say, it now looks like this: `Error::InvalidTransmitPower(usize,usize)`  