### PR TITLE
Add temp field to Stat struct

### DIFF
--- a/PROTOCOL.TXT
+++ b/PROTOCOL.TXT
@@ -241,7 +241,7 @@ Example (white-spaces, indentation and newlines added for readability):
 	"ackr":100.0,
 	"dwnb":2,
 	"txnb":2,
-    "temp": 23.2
+	"temp":23.2
 }}
 ```
 

--- a/PROTOCOL.TXT
+++ b/PROTOCOL.TXT
@@ -225,6 +225,7 @@ That object contains the status of the gateway, with the following fields:
  ackr | number | Percentage of upstream datagrams that were acknowledged
  dwnb | number | Number of downlink datagrams received (unsigned integer)
  txnb | number | Number of packets emitted (unsigned integer)
+ temp | number | Current temperature in degree celcius (float)
 
 Example (white-spaces, indentation and newlines added for readability):
 
@@ -239,7 +240,8 @@ Example (white-spaces, indentation and newlines added for readability):
 	"rxfw":2,
 	"ackr":100.0,
 	"dwnb":2,
-	"txnb":2
+	"txnb":2,
+    "temp": 23.2
 }}
 ```
 

--- a/src/packet/push_data.rs
+++ b/src/packet/push_data.rs
@@ -326,6 +326,7 @@ rxfw | number | Number of radio packets forwarded (unsigned integer)
 ackr | number | Percentage of upstream datagrams that were acknowledged
 dwnb | number | Number of downlink datagrams received (unsigned integer)
 txnb | number | Number of packets emitted (unsigned integer)
+temp | number | Current temperature in degree celcius (float)
 */
 
 // the order of this is important as it makes us identical to Semtech
@@ -345,6 +346,7 @@ pub struct Stat {
     ackr: Option<f64>,
     dwnb: u64,
     txnb: u64,
+    temp: Option<f64>,
 }
 
 impl SerializablePacket for Packet {


### PR DESCRIPTION
As per https://github.com/Lora-net/sx1302_hal/blob/master/packet_forwarder/PROTOCOL.md the protocol seems to have been extended to include an (optional) field for temperature in the `"stat"` object. For monitoring this field can be quite useful and since multiplexers like gwmp-mux interprete these fields, it would be good to add these here, too.